### PR TITLE
Add interactive graph for saved times

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,5 +57,17 @@ def delete_time():
 
     return jsonify({"status": "error", "message": "Time not found"})
 
+
+@app.route('/times')
+def get_times():
+    times = []
+    if os.path.exists(TIMES_FILE):
+        with open(TIMES_FILE, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    times.append(line)
+    return jsonify(times)
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/script.js
+++ b/static/script.js
@@ -2,6 +2,10 @@ document.addEventListener('DOMContentLoaded', function() {
     const timerDisplay = document.getElementById('timer');
     const statusDisplay = document.getElementById('status');
     const timesList = document.getElementById('times-list');
+    const showGraphBtn = document.getElementById('show-graph-btn');
+    const graphContainer = document.getElementById('graph-container');
+    const chartCanvas = document.getElementById('times-chart');
+    let chart = null;
 
     let startTime;
     let elapsedTime = 0;
@@ -120,4 +124,67 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('.delete-btn').forEach(btn => {
         btn.addEventListener('click', handleDelete);
     });
+
+    if (showGraphBtn) {
+        showGraphBtn.addEventListener('click', toggleChart);
+    }
+
+    function toggleChart() {
+        if (graphContainer.style.display === 'none' || graphContainer.style.display === '') {
+            loadChart();
+        } else {
+            graphContainer.classList.add('hidden');
+            setTimeout(() => {
+                graphContainer.style.display = 'none';
+            }, 500);
+        }
+    }
+
+    function loadChart() {
+        fetch('/times')
+            .then(res => res.json())
+            .then(times => {
+                const parsed = times.map(t => parseTime(t));
+                const labels = parsed.map((_, i) => i + 1);
+                if (!chart) {
+                    chart = new Chart(chartCanvas.getContext('2d'), {
+                        type: 'line',
+                        data: {
+                            labels: labels,
+                            datasets: [{
+                                label: 'Solve Time (ms)',
+                                data: parsed,
+                                borderColor: '#3498db',
+                                backgroundColor: 'rgba(52, 152, 219, 0.2)',
+                                tension: 0.3
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            animation: {
+                                duration: 700,
+                                easing: 'easeOutQuart'
+                            },
+                            scales: {
+                                y: {
+                                    beginAtZero: true
+                                }
+                            }
+                        }
+                    });
+                } else {
+                    chart.data.labels = labels;
+                    chart.data.datasets[0].data = parsed;
+                    chart.update();
+                }
+                graphContainer.style.display = 'block';
+                graphContainer.classList.remove('hidden');
+                graphContainer.classList.add('visible');
+            });
+    }
+
+    function parseTime(str) {
+        const [min, sec, ms] = str.split(':');
+        return parseInt(min) * 60000 + parseInt(sec) * 1000 + parseInt(ms);
+    }
 });

--- a/static/style.css
+++ b/static/style.css
@@ -92,6 +92,37 @@ h2 {
     color: #c0392b;
 }
 
+/* Graph styles */
+.graph-btn {
+    display: block;
+    margin: 15px auto;
+    padding: 10px 20px;
+    background-color: #3498db;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background-color 0.3s;
+}
+
+.graph-btn:hover {
+    background-color: #2980b9;
+}
+
+.graph-container {
+    margin-top: 20px;
+    max-height: 400px;
+    transition: opacity 0.5s ease;
+}
+
+.graph-container.hidden {
+    opacity: 0;
+}
+.graph-container.visible {
+    opacity: 1;
+}
+
 /* Animation for running timer */
 .running {
     animation: pulse 1s infinite alternate;

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Timer App</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <div class="container">
@@ -24,6 +25,10 @@
                     <button class="delete-btn" data-time="{{ time }}">×</button>
                 </div>
                 {% endfor %}
+            </div>
+            <button id="show-graph-btn" class="graph-btn">Show Graph</button>
+            <div class="graph-container" id="graph-container" style="display:none;">
+                <canvas id="times-chart"></canvas>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add Chart.js to `index.html` and create graph container
- style the graph button and container with transitions
- implement `/times` endpoint to return saved times as JSON
- build interactive chart logic in `static/script.js`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683b8e81b7d0832fb478a03b3b4c769d